### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-SpecialFunctions = "0.8, 1"
+SpecialFunctions = "0.8, 1, 2"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.