### PR TITLE
hotfix for `face_basis(::Quad, ...)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
     tags: '*'
 jobs:
   test:

--- a/src/warpblend_interp_nodes.jl
+++ b/src/warpblend_interp_nodes.jl
@@ -11,7 +11,7 @@ Returns list of edges for a specific element (elem = Tri(), Pyr(), or Tet()).
 get_edge_list(elem::AbstractElemShape)
 
 get_edge_list(::Tri)  = SVector(1, 2), SVector(2, 3), SVector(3, 1)
-get_edge_list(::Quad) = SVector(1, 2), SVector(2, 3), SVector(3, 4), SVector(4, 1) # not used directly but included for completeness
+get_edge_list(::Quad) = SVector(1, 3), SVector(2, 4), SVector(1, 2), SVector(3, 4) 
 get_edge_list(::Tet)  = SVector(1, 4), SVector(4, 3), SVector(3, 1), SVector(1, 2), SVector(3, 2), SVector(4, 2)
 get_edge_list(::Pyr)  = SVector(1, 2), SVector(2, 4), SVector(3, 4), SVector(3, 1), SVector(1, 5), SVector(2, 5), SVector(3, 5), SVector(4, 5)
 

--- a/src/warpblend_interp_nodes.jl
+++ b/src/warpblend_interp_nodes.jl
@@ -6,12 +6,11 @@
 """
     get_edge_list(elem::AbstractElemShape)
 
-Returns list of edges for a specific element (elem = Tri(), Pyr(), or Tet()).
+Returns list of edges for a specific element (elem = Tri(), Pyr(), Hex(), or Tet()).
 """
 get_edge_list(elem::AbstractElemShape)
 
-get_edge_list(::Tri)  = SVector(1, 2), SVector(2, 3), SVector(3, 1)
-get_edge_list(::Quad) = SVector(1, 3), SVector(2, 4), SVector(1, 2), SVector(3, 4) 
+get_edge_list(elem::Union{Tri, Quad}) = SVector{2}.(find_face_nodes(elem, equi_nodes(elem, 1)...))
 get_edge_list(::Tet)  = SVector(1, 4), SVector(4, 3), SVector(3, 1), SVector(1, 2), SVector(3, 2), SVector(4, 2)
 get_edge_list(::Pyr)  = SVector(1, 2), SVector(2, 4), SVector(3, 4), SVector(3, 1), SVector(1, 5), SVector(2, 5), SVector(3, 5), SVector(4, 5)
 
@@ -26,7 +25,7 @@ get_edge_list(::Pyr)  = SVector(1, 2), SVector(2, 4), SVector(3, 4), SVector(3, 
  
 get_edge_list(::Hex) = SVector(1, 5), SVector(3, 7), SVector(2, 6), SVector(4, 8), 
                        SVector(1, 3), SVector(2, 4), SVector(1, 2), SVector(3, 4), 
-                       SVector(5, 7), SVector(6, 8), SVector(5, 6), SVector(7, 8)                        
+                       SVector(5, 7), SVector(6, 8), SVector(5, 6), SVector(7, 8)
 
 
 get_vertices(elem::AbstractElemShape) = equi_nodes(elem, 1)

--- a/src/warpblend_interp_nodes.jl
+++ b/src/warpblend_interp_nodes.jl
@@ -91,7 +91,7 @@ function edge_basis(N, vertices, edges, basis1D, vertex_functions, rst...)
         r1D_edge = V1[:,e[1]] - V1[:,e[2]]
         V1D, _ = basis1D(N-2, r1D_edge)
         for i in axes(V1D, 2)
-            V[:,id] = V1D[:,i] .* V1[:,e[1]] .* V1[:,e[2]]
+            V[:, id] = V1D[:, i] .* V1[:, e[1]] .* V1[:, e[2]]
             id += 1
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,8 +84,11 @@ area(elem::Tri) = 2.0
         Vq1D = vandermonde(Line(), N, quad_nodes(Line(), N)[1])
         @test Vq ≈ kron(Vq1D, Vq1D)
 
-        @test NodesAndModes.get_edge_list(Quad()) == ([1,2], [2,3], [3,4], [4,1])
         @test NodesAndModes.face_basis(Quad(), N, r, s) ≈ NodesAndModes.edge_basis(Quad(), N, r, s)
+
+        # check invertibility of face basis matrix
+        Fmask = hcat(NodesAndModes.find_face_nodes(Quad(), r, s)...)
+        @test cond(NodesAndModes.face_basis(Quad(), N, r[Fmask], s[Fmask])) < 1e3
     end
 end
 


### PR DESCRIPTION
Fixes the construction of `face_basis` for quadrilateral elements (faces were previously defined incorrectly)