### PR TITLE
Support JuliaFormatter.jl v1.0.60

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,8 @@
+# Use SciML style: https://github.com/SciML/SciMLStyle
+style = "sciml"
+
+# Python style alignment. See https://github.com/domluna/JuliaFormatter.jl/pull/732.
+yas_style_nesting = true
+
+# Align struct fields for better readability of large struct definitions
+align_struct_field = true

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,17 +1,13 @@
 using Documenter
 using NodesAndModes
 
-makedocs(
-    sitename = "NodesAndModes.jl",
-    repo = "https://github.com/jlchan/NodesAndModes.jl",
-    modules=[NodesAndModes],
-    pages = [
-        "Home" => "index.md",
-        "Index" => "function_index.md",
-        "Authors" => "authors.md"
-    ]
-)
+makedocs(sitename = "NodesAndModes.jl",
+         repo = "https://github.com/jlchan/NodesAndModes.jl",
+         modules = [NodesAndModes],
+         pages = [
+             "Home" => "index.md",
+             "Index" => "function_index.md",
+             "Authors" => "authors.md"
+         ])
 
-deploydocs(
-    repo = "github.com/jlchan/NodesAndModes.jl",
-)
+deploydocs(repo = "github.com/jlchan/NodesAndModes.jl")

--- a/src/common_functions.jl
+++ b/src/common_functions.jl
@@ -3,8 +3,8 @@
 
 Computes the generalized Vandermonde matrix V of degree N at points (r,s,t).
 """
-vandermonde(elem::AbstractElemShape, N, rst...) = first(basis(elem,N,rst...))
-vandermonde(elem::Line, N, r) = first(basis(elem,N,r)) # specialize for 1D
+vandermonde(elem::AbstractElemShape, N, rst...) = first(basis(elem, N, rst...))
+vandermonde(elem::Line, N, r) = first(basis(elem, N, r)) # specialize for 1D
 
 """
     grad_vandermonde(elem::AbstractElemShape, N, rst...)
@@ -12,8 +12,7 @@ vandermonde(elem::Line, N, r) = first(basis(elem,N,r)) # specialize for 1D
 Computes the generalized Vandermonde derivative matrix V of degree N at points (r,s,t).
 """
 grad_vandermonde(elem::AbstractElemShape, N, rst...) = basis(elem, N, rst...)[2:end]
-grad_vandermonde(elem::Line, N, r) = last(basis(elem,N,r)) # specialize for 1D
-
+grad_vandermonde(elem::Line, N, r) = last(basis(elem, N, r)) # specialize for 1D
 
 """
     nodes(elem::AbstractElemShape,N)
@@ -24,17 +23,14 @@ Default routine for elem = Tet(), Pyr(), Tri().
 For Quad(), Hex(), Wedge() elements, nodes(...) returns interpolation points constructed
 using a tensor product of lower-dimensional nodes. 
 """
-nodes(elem::AbstractElemShape,N) = build_warped_nodes(elem, N, nodes(Line(),N))
-
-
+nodes(elem::AbstractElemShape, N) = build_warped_nodes(elem, N, nodes(Line(), N))
 
 """
     basis(elem::AbstractElemShape, N, rst...)
 
 Computes orthonormal basis of degree N at tuple of coordinate arrays (r,s,t).
 """
-basis(elem::AbstractElemShape,N,rst...)
-
+basis(elem::AbstractElemShape, N, rst...)
 
 """
     equi_nodes(elem::AbstractElemShape, N)
@@ -49,7 +45,6 @@ equi_nodes(elem::AbstractElemShape, N)
 Compute quadrature nodes and weights exact for (at least) degree 2N polynomials.
 """
 quad_nodes(elem::AbstractElemShape, N)
-
 
 """
     stroud_quad_nodes(elem::AbstractElemShape,N)

--- a/src/hex_element.jl
+++ b/src/hex_element.jl
@@ -1,8 +1,8 @@
 function basis(elem::Hex, N, r, s, t)
-    Np = convert(Int, (N+1)^3)
-    V, Vr, Vs, Vt = ntuple(x->zeros(length(r), Np), 4)
-    tmp_array = zeros(N+1)
-    for ii in eachindex(r, s, t)                                                
+    Np = convert(Int, (N + 1)^3)
+    V, Vr, Vs, Vt = ntuple(x -> zeros(length(r), Np), 4)
+    tmp_array = zeros(N + 1)
+    for ii in eachindex(r, s, t)
         sk = 1
         for k in 0:N
             P_k = jacobiP(t[ii], 0, 0, k)
@@ -13,14 +13,14 @@ function basis(elem::Hex, N, r, s, t)
                 for j in 0:N
                     P_j = jacobiP(s[ii], 0, 0, j)
                     dP_j = grad_jacobiP(s[ii], 0, 0, j)
-                    
-                    V[ii, sk]  = P_i * P_j * P_k
+
+                    V[ii, sk] = P_i * P_j * P_k
                     Vr[ii, sk] = dP_i * P_j * P_k
                     Vs[ii, sk] = P_i * dP_j * P_k
                     Vt[ii, sk] = P_i * P_j * dP_k
-                   
+
                     sk += 1
-                end                
+                end
             end
         end
     end
@@ -28,25 +28,22 @@ function basis(elem::Hex, N, r, s, t)
     return V, Vr, Vs, Vt
 end
 
-
 # ===================================================
 
 function nodes(elem::Hex, N)
-    r1D, _ = gauss_lobatto_quad(0,0,N)
-    return vec.(meshgrid(r1D,r1D,r1D))
+    r1D, _ = gauss_lobatto_quad(0, 0, N)
+    return vec.(meshgrid(r1D, r1D, r1D))
 end
-
 
 function equi_nodes(elem::Hex, N)
-    r1D = LinRange(-1,1,N+1)
-    return vec.(meshgrid(r1D,r1D,r1D))
+    r1D = LinRange(-1, 1, N + 1)
+    return vec.(meshgrid(r1D, r1D, r1D))
 end
 
-
 function quad_nodes(elem::Hex, N)
-    r1D,w1D = gauss_quad(0,0,N)
-    r,s,t = vec.(meshgrid(r1D,r1D,r1D))
-    wr,ws,wt = vec.(meshgrid(w1D,w1D,w1D))
-    w = @. wr*ws*wt
-    return r,s,t,w
+    r1D, w1D = gauss_quad(0, 0, N)
+    r, s, t = vec.(meshgrid(r1D, r1D, r1D))
+    wr, ws, wt = vec.(meshgrid(w1D, w1D, w1D))
+    w = @. wr * ws * wt
+    return r, s, t, w
 end

--- a/src/line_element.jl
+++ b/src/line_element.jl
@@ -5,10 +5,10 @@ Computes the generalized Vandermonde matrix V of degree N (along with the
 derivative matrix Vr) at points r.
 """
 function basis(elem::Line, N, r)
-    V1D, Vr1D = ntuple(x->zeros(length(r), N+1),2)
-    for j = 1:N+1
-        V1D[:,j] .= jacobiP(r[:], 0, 0, j-1)
-        Vr1D[:,j] .= grad_jacobiP(r[:], 0, 0, j-1)
+    V1D, Vr1D = ntuple(x -> zeros(length(r), N + 1), 2)
+    for j in 1:(N + 1)
+        V1D[:, j] .= jacobiP(r[:], 0, 0, j - 1)
+        Vr1D[:, j] .= grad_jacobiP(r[:], 0, 0, j - 1)
     end
     return V1D, Vr1D
 end
@@ -25,7 +25,7 @@ nodes(elem::Line, N) = first(gauss_lobatto_quad(0, 0, N))
 
 Computes equally spaced nodes of degree N.
 """
-equi_nodes(elem::Line, N) = collect(LinRange(-1, 1, N+1))
+equi_nodes(elem::Line, N) = collect(LinRange(-1, 1, N + 1))
 
 """
     quad_nodes(elem::Line,N)

--- a/src/meshgrid.jl
+++ b/src/meshgrid.jl
@@ -35,7 +35,8 @@ For more information, see the MATLAB documentation.
 Copied and pasted directly from [VectorizedRoutines.jl](https://github.com/ChrisRackauckas/VectorizedRoutines.jl/blob/master/src/matlab.jl).
 Using VectorizedRoutines.jl directly causes Pkg versioning issues with SpecialFunctions.jl
 """
-function meshgrid(vx::AbstractVector{T}, vy::AbstractVector{T},
+function meshgrid(vx::AbstractVector{T},
+                  vy::AbstractVector{T},
                   vz::AbstractVector{T}) where {T}
     m, n, o = length(vy), length(vx), length(vz)
     vx = reshape(vx, 1, n, 1)

--- a/src/nodes_and_modes_1D.jl
+++ b/src/nodes_and_modes_1D.jl
@@ -4,37 +4,35 @@
 Computes Legendre-Gauss-Lobatto quadrature points and weights with Jacobi weights α,β.
 """
 function gauss_lobatto_quad(α::Int, β::Int, N)
-
     if !(iszero(α) && iszero(β))
         error("alpha/beta must be zero for Lobatto")
     end
 
-    x = zeros(N+1)
-    w = zeros(N+1)
+    x = zeros(N + 1)
+    w = zeros(N + 1)
     if N == 0
-        x[1] = 0.
-        w[1] = 2.
+        x[1] = 0.0
+        w[1] = 2.0
     elseif N == 1
         x[1] = -1.0
         x[2] = 1.0
         w[1] = 1.0
         w[2] = 1.0
-    elseif N==2
-        x[1] = -1.
-        x[2] = 0.
-        x[3] = 1.
+    elseif N == 2
+        x[1] = -1.0
+        x[2] = 0.0
+        x[3] = 1.0
         w[1] = 0.333333333333333
         w[2] = 1.333333333333333
         w[3] = 0.333333333333333
     else
-        xint, wint = gauss_quad(α+1, β+1, N-2)
-        x = vcat(-1,xint,1)
-        wend = 2/(N*(N+1))
-        w = vcat(wend, (@. wint / (1-xint^2)) ,wend)
+        xint, wint = gauss_quad(α + 1, β + 1, N - 2)
+        x = vcat(-1, xint, 1)
+        wend = 2 / (N * (N + 1))
+        w = vcat(wend, (@. wint / (1 - xint^2)), wend)
     end
-    return x[:],w[:]
+    return x[:], w[:]
 end
-
 
 """
     gauss_quad(α, β, N)
@@ -44,20 +42,25 @@ Compute nodes and weights for Gaussian quadrature with Jacobi weights (α,β).
 function gauss_quad(α, β, N)
     if N == 0
         x = [-(α - β) / (α + β + 2)]
-        w = [2.]
+        w = [2.0]
         return x, w
     end
 
-    J = zeros(N+1, N+1)
-    h₁ = @. 2 * (0:N) + α + β    
-    J = diagm(0 => @. -1/2 * (α^2 - β^2) / (h₁ + 2) / h₁) + 
-        diagm(1 => @. 2 / (h₁[1:N] + 2) * sqrt((1:N) * ((1:N) + α + β) * ((1:N) + α) * ((1:N) + β) / (h₁[1:N] + 1) / (h₁[1:N] + 3)))
+    J = zeros(N + 1, N + 1)
+    h₁ = @. 2 * (0:N) + α + β
+    J = diagm(0 => @. -1 / 2 * (α^2 - β^2) / (h₁ + 2) / h₁) +
+        diagm(1 => @. 2 / (h₁[1:N] + 2) *
+                      sqrt((1:N) * ((1:N) + α + β) * ((1:N) + α) * ((1:N) + β) /
+                           (h₁[1:N] + 1) /
+                           (h₁[1:N] + 3)))
     if α + β < 10 * eps()
-        J[1,1] = 0.0
+        J[1, 1] = 0.0
     end
 
-    x, V = eigen(Symmetric(J+J'))
-    w = @. transpose(V[1,:])^2 * 2^(α + β + 1) / (α + β + 1) * gamma(α + 1) * gamma(β + 1) / gamma(α + β + 1)
+    x, V = eigen(Symmetric(J + J'))
+    w = @. transpose(V[1, :])^2 * 2^(α + β + 1) / (α + β + 1) *
+           gamma(α + 1) *
+           gamma(β + 1) / gamma(α + β + 1)
     return x[:], w[:]
 end
 
@@ -76,7 +79,7 @@ function jacobiP(x, α, β, N)
 end
 
 # non-allocating vector version
-function jacobiP!(out, x, α, β, N)    
+function jacobiP!(out, x, α, β, N)
     for i in eachindex(x)
         out[i] = jacobiP(x[i], α, β, N)
     end
@@ -85,7 +88,6 @@ end
 
 # non-allocating scalar version of jacobiP
 function jacobiP(x::T, α, β, N) where {T <: Real}
-
     γ₀ = 2^(α + β + 1) / (α + β + 1) * gamma(α + 1) * gamma(β + 1) / gamma(α + β + 1)
     PL = 1.0 / sqrt(γ₀)
     if N == 0
@@ -95,17 +97,19 @@ function jacobiP(x::T, α, β, N) where {T <: Real}
     γ₁ = (α + 1) * (β + 1) / (α + β + 3) * γ₀
     PL_prev = PL
     PL = ((α + β + 2) * x / 2 + (α - β) / 2) / sqrt(γ₁)
-    if N == 1        
+    if N == 1
         return PL
     end
 
-    aold = 2 / (2+α+β) * sqrt((α+1) * (β+1) / (α + β + 3))
+    aold = 2 / (2 + α + β) * sqrt((α + 1) * (β + 1) / (α + β + 3))
     PL_prev2 = PL_prev
     PL_prev = PL
-    for i = 1:N-1
+    for i in 1:(N - 1)
         h₁ = 2i + α + β
-        anew = 2 / (h₁+2) * sqrt((i+1) * (i+1+α+β) * (i+1+α) * (i+1+β) / (h₁+1) / (h₁+3))
-        bnew = -(α^2-β^2) / h₁ / (h₁+2)
+        anew = 2 / (h₁ + 2) *
+               sqrt((i + 1) * (i + 1 + α + β) * (i + 1 + α) * (i + 1 + β) / (h₁ + 1) /
+                    (h₁ + 3))
+        bnew = -(α^2 - β^2) / h₁ / (h₁ + 2)
         PL = 1 / anew * (-aold * PL_prev2 + (x - bnew) * PL_prev)
         aold = anew
 
@@ -113,7 +117,7 @@ function jacobiP(x::T, α, β, N) where {T <: Real}
         PL_prev2 = PL_prev
         PL_prev = PL
     end
-    
+
     return PL
 end
 
@@ -136,7 +140,7 @@ end
 
 function grad_jacobiP(r::T, α, β, N) where {T <: Real}
     if N != 0
-        return sqrt(N * (N+α+β+1)) * jacobiP(r, α+1, β+1, N-1)
+        return sqrt(N * (N + α + β + 1)) * jacobiP(r, α + 1, β + 1, N - 1)
     else
         return zero(typeof(r))
     end

--- a/src/pyr_element.jl
+++ b/src/pyr_element.jl
@@ -11,7 +11,7 @@ Warning: nodal derivative matrices may contain errors for nodes at t = 1.
 A way to avoid this is to use weak differentiation matrices computed using
 quadrature rules with only interior nodes.
 """
-function basis(elem::Pyr, N, r, s, t, tol = 1e3*eps())
+function basis(elem::Pyr, N, r, s, t, tol = 1e3 * eps())
 
     # convert to abc
     a = @. 2 * (r + 1) / (1 - t) - 1
@@ -32,28 +32,30 @@ function basis(elem::Pyr, N, r, s, t, tol = 1e3*eps())
     dcdt = 1
 
     Np = (N + 1) * (N + 2) * (2 * N + 3) ÷ 6
-    V, Vr, Vs, Vt = ntuple(x->zeros(length(r), Np), 4)
+    V, Vr, Vs, Vt = ntuple(x -> zeros(length(r), Np), 4)
 
     ind = 1
-    for k = 0:N
+    for k in 0:N
         # make nodal quad basis
         bq, aq, wab = quad_nodes(Quad(), k)
         VDM, _ = basis(Quad(), k, aq, bq)
         VDMab, Va, Vb = basis(Quad(), k, a, b)
-        Vab, DVa, DVb = map(A->A / VDM, (VDMab, Va, Vb))
+        Vab, DVa, DVb = map(A -> A / VDM, (VDMab, Va, Vb))
 
-        CNk = (N+2) / (2^(2*k+2) * (2*k+3))
-        pNk = jacobiP(c, 2*k+3, 0, N-k)
-        pc = @. ((1-c) / 2)^k * pNk
-        dpNk = grad_jacobiP(c, 2*k+3, 0, N-k)
-        dpc = @. ((1-c)/2)^k * dpNk - (k/2^k) * ((1 - c)^(k - 1)) * pNk
+        CNk = (N + 2) / (2^(2 * k + 2) * (2 * k + 3))
+        pNk = jacobiP(c, 2 * k + 3, 0, N - k)
+        pc = @. ((1 - c) / 2)^k * pNk
+        dpNk = grad_jacobiP(c, 2 * k + 3, 0, N - k)
+        dpc = @. ((1 - c) / 2)^k * dpNk - (k / 2^k) * ((1 - c)^(k - 1)) * pNk
 
-        for ij = 1:(k+1)^2
+        for ij in 1:((k + 1)^2)
             scale = 1 / sqrt(CNk * wab[ij]) # normalization
-            @. V[:,ind]  = scale * Vab[:,ij] * pc
-            @. Vr[:,ind] = scale * (DVa[:,ij] * dadr) * pc
-            @. Vs[:,ind] = scale * (DVb[:,ij] * dbds) * pc
-            @. Vt[:,ind] = scale * ((DVa[:,ij] * dadt + DVb[:,ij] * dbdt) * pc + Vab[:,ij] * dpc * dcdt)
+            @. V[:, ind] = scale * Vab[:, ij] * pc
+            @. Vr[:, ind] = scale * (DVa[:, ij] * dadr) * pc
+            @. Vs[:, ind] = scale * (DVb[:, ij] * dbds) * pc
+            @. Vt[:, ind] = scale *
+                            ((DVa[:, ij] * dadt + DVb[:, ij] * dbdt) * pc +
+                             Vab[:, ij] * dpc * dcdt)
             ind += 1
         end
     end
@@ -67,8 +69,8 @@ Converts from Stroud coordinates (a,b,c) on [-1,1]^3 to reference
 element coordinates (r,s,t).
 """
 function abctorst(elem::Pyr, a, b, c)
-    r = @. .5 * (1 + a) * (1 - c) - 1
-    s = @. .5 * (1 + b) * (1 - c) - 1
+    r = @. 0.5 * (1 + a) * (1 - c) - 1
+    s = @. 0.5 * (1 + b) * (1 - c) - 1
     t = @. c
     return r, s, t
 end
@@ -80,12 +82,11 @@ Converts from reference element coordinates (r,s,t) to Stroud
 coordinates (a,b,c) on [-1,1]^3.
 """
 function rsttoabc(::Pyr, r, s, t)
-    a = @. 2 * (r + 1) / (1 - t) - 1 
+    a = @. 2 * (r + 1) / (1 - t) - 1
     b = @. 2 * (s + 1) / (1 - t) - 1
     c = @. t
     return a, b, c
 end
-
 
 """
     nodes(elem::Pyr,N)
@@ -95,7 +96,6 @@ points. Triangular face nodes coincide with Tri.nodes(N), quadrilateral face nod
 coincide with tensor product (N+1)-point Lobatto points.
 """
 function nodes(elem::Pyr, N)
-
     if N == 1
         return equi_nodes(Pyr(), N)
     end
@@ -103,13 +103,14 @@ function nodes(elem::Pyr, N)
     # append quad face nodes
     r1D_equi = equi_nodes(Line(), N)
     rst_equi = interp_1D_to_edges(Pyr(), r1D_equi)
-    quad_face_pts_equi = (vec.(meshgrid(r1D_equi[2:end-1]))..., -ones((N - 1) * (N - 1)))
+    quad_face_pts_equi = (vec.(meshgrid(r1D_equi[2:(end - 1)]))...,
+                          -ones((N - 1) * (N - 1)))
     append!.(rst_equi, quad_face_pts_equi)
 
     # append quad face nodes
     r1D = nodes(Line(), N)
     rst_lobatto = interp_1D_to_edges(Pyr(), r1D)
-    quad_face_pts = (vec.(meshgrid(r1D[2:end-1]))..., -ones((N - 1) * (N - 1)))
+    quad_face_pts = (vec.(meshgrid(r1D[2:(end - 1)]))..., -ones((N - 1) * (N - 1)))
     append!.(rst_lobatto, quad_face_pts)
 
     # append quad face "bubble" basis functions
@@ -118,26 +119,26 @@ function nodes(elem::Pyr, N)
         # WARNING: assumes first 4 vertices of Pyr = quad vertices
         # also assumes first 5 cols of V_edge = vertex functions for Pyr
         V_quad_face = zeros(length(first(rst)), (N - 1) * (N - 1))
-        V_quad = vandermonde(Quad(), N-2, rst[1], rst[2])
-        V_quad_bubble = @. V_edge[:,1] * V_edge[:,2] * V_edge[:,3] * V_edge[:,4]
-        for i = 1:size(V_quad_face, 2)
-            @. V_quad_face[:,i] = V_quad_bubble * V_quad[:,i]
+        V_quad = vandermonde(Quad(), N - 2, rst[1], rst[2])
+        V_quad_bubble = @. V_edge[:, 1] * V_edge[:, 2] * V_edge[:, 3] * V_edge[:, 4]
+        for i in 1:size(V_quad_face, 2)
+            @. V_quad_face[:, i] = V_quad_bubble * V_quad[:, i]
         end
         return hcat(V_edge, V_quad_face)
     end
 
     # same interp problem as before
     V_edge_face = edge_face_pyr_basis(N, rst_equi)
-    c = (x->V_edge_face \ x).(rst_lobatto) # should be lsq solve
-    return (x->edge_face_pyr_basis(N, equi_nodes(elem, N)) * x).(c)
+    c = (x -> V_edge_face \ x).(rst_lobatto) # should be lsq solve
+    return (x -> edge_face_pyr_basis(N, equi_nodes(elem, N)) * x).(c)
 end
 
 function equi_nodes(elem::Pyr, N)
     a, b, c = ntuple(x -> Float64[], 3)
-    c1D = LinRange(-1, 1, N+1)
-    for k = N:-1:0
-        if k==0
-            r1D = [.5]
+    c1D = LinRange(-1, 1, N + 1)
+    for k in N:-1:0
+        if k == 0
+            r1D = [0.5]
         else
             r1D = LinRange(-1, 1, k + 1)
         end
@@ -151,7 +152,6 @@ end
 quad_nodes(elem::Pyr, N) = stroud_quad_nodes(elem, N)
 
 function stroud_quad_nodes(elem::Pyr, N)
-
     a1D, w1D = gauss_quad(0, 0, N)
     c1D, wc1D = gauss_quad(2, 0, N)
 

--- a/src/quad_element.jl
+++ b/src/quad_element.jl
@@ -2,20 +2,19 @@
 function basis(elem::Quad, N, r, s)
     Np = convert(Int, (N + 1) * (N + 1))
     sk = 1
-    V, Vr, Vs = ntuple(x->zeros(length(r), Np), 3)
-    for j = 0:N
+    V, Vr, Vs = ntuple(x -> zeros(length(r), Np), 3)
+    for j in 0:N
         P_j = jacobiP(s, 0, 0, j)
-        for i = 0:N
+        for i in 0:N
             P_i = jacobiP(r, 0, 0, i)
-            V[:, sk]  = P_i .* P_j
+            V[:, sk] = P_i .* P_j
             Vr[:, sk] = grad_jacobiP(r, 0, 0, i) .* P_j
             Vs[:, sk] = P_i .* grad_jacobiP(s, 0, 0, j)
             sk += 1
         end
     end
-    return V,Vr,Vs
+    return V, Vr, Vs
 end
-
 
 function nodes(elem::Quad, N)
     r1D, w1D = gauss_lobatto_quad(0, 0, N)
@@ -23,14 +22,13 @@ function nodes(elem::Quad, N)
     return r[:], s[:]
 end
 
-
 function equi_nodes(elem::Quad, N)
     r1D = LinRange(-1, 1, N + 1)
     s, r = meshgrid(r1D)
     return r[:], s[:]
 end
 
-function quad_nodes(elem::Quad,N)
+function quad_nodes(elem::Quad, N)
     r1D, w1D = gauss_quad(0, 0, N)
     s, r = meshgrid(r1D)
     ws, wr = meshgrid(w1D)

--- a/src/tet_element.jl
+++ b/src/tet_element.jl
@@ -8,10 +8,10 @@
 Evaluate 3D "Legendre" basis phi_ijk at (a,b,c) coordinates on the [-1,1] cube
 """
 function simplex_3D(a, b, c, i, j, k)
-    h1 = jacobiP(a, 0,0, i)
-    h2 = jacobiP(b, 2*i+1, 0, j)
-    h3 = jacobiP(c, 2*(i+j)+2, 0, k)
-    return @. 2 * sqrt(2) * h1 * h2 * ((1-b)^i) * h3 * ((1-c)^(i+j))
+    h1 = jacobiP(a, 0, 0, i)
+    h2 = jacobiP(b, 2 * i + 1, 0, j)
+    h3 = jacobiP(c, 2 * (i + j) + 2, 0, k)
+    return @. 2 * sqrt(2) * h1 * h2 * ((1 - b)^i) * h3 * ((1 - c)^(i + j))
 end
 
 """
@@ -23,67 +23,65 @@ index, or order, (id,jd,kd) at (a,b,c)
 
 function grad_simplex_3D(a, b, c, id, jd, kd)
     fa = jacobiP(a, 0, 0, id)
-    gb = jacobiP(b, 2*id+1, 0, jd)
-    hc = jacobiP(c, 2*(id+jd)+2, 0, kd)
+    gb = jacobiP(b, 2 * id + 1, 0, jd)
+    hc = jacobiP(c, 2 * (id + jd) + 2, 0, kd)
 
     dfa = grad_jacobiP(a, 0, 0, id)
-    dgb = grad_jacobiP(b, 2*id+1, 0, jd)
-    dhc = grad_jacobiP(c, 2*(id+jd)+2, 0, kd)
+    dgb = grad_jacobiP(b, 2 * id + 1, 0, jd)
+    dhc = grad_jacobiP(c, 2 * (id + jd) + 2, 0, kd)
 
     # r-derivative
     V3Dr = @. dfa * (gb * hc)
     if id > 0
-        V3Dr = @. V3Dr * ((0.5 * (1-b))^(id-1))
+        V3Dr = @. V3Dr * ((0.5 * (1 - b))^(id - 1))
     end
-    if id+jd > 0
-        V3Dr = @. V3Dr * ((0.5 * (1-c))^(id+jd-1))
+    if id + jd > 0
+        V3Dr = @. V3Dr * ((0.5 * (1 - c))^(id + jd - 1))
     end
 
     # s-derivative
-    V3Ds = @. 0.5 * (1+a) * V3Dr
-    tmp = @. dgb * ((0.5 * (1-b))^id)
+    V3Ds = @. 0.5 * (1 + a) * V3Dr
+    tmp = @. dgb * ((0.5 * (1 - b))^id)
     if id > 0
-        tmp = @. tmp + (-0.5*id) * (gb * (0.5*(1-b))^(id-1))
+        tmp = @. tmp + (-0.5 * id) * (gb * (0.5 * (1 - b))^(id - 1))
     end
-    if id+jd > 0
-        tmp = @. tmp * ((0.5 * (1-c))^(id+jd-1))
+    if id + jd > 0
+        tmp = @. tmp * ((0.5 * (1 - c))^(id + jd - 1))
     end
     tmp = @. fa * (tmp * hc)
     V3Ds = @. V3Ds + tmp
 
     # t-derivative
-    V3Dt = @. 0.5 * (1+a) * V3Dr + 0.5 * (1+b) * tmp
-    tmp = @. dhc * ((0.5 * (1-c))^(id+jd))
-    if id+jd > 0
-      tmp = @. tmp - 0.5 * (id+jd) * (hc * ((0.5 * (1-c))^(id+jd-1)))
+    V3Dt = @. 0.5 * (1 + a) * V3Dr + 0.5 * (1 + b) * tmp
+    tmp = @. dhc * ((0.5 * (1 - c))^(id + jd))
+    if id + jd > 0
+        tmp = @. tmp - 0.5 * (id + jd) * (hc * ((0.5 * (1 - c))^(id + jd - 1)))
     end
     tmp = @. fa * (gb * tmp)
-    tmp = @. tmp * ((0.5 * (1-b))^id)
+    tmp = @. tmp * ((0.5 * (1 - b))^id)
     V3Dt = @. V3Dt + tmp
 
     # normalize
-    V3Dr = @. V3Dr * (2^(2*id+jd + 1.5))
-    V3Ds = @. V3Ds * (2^(2*id+jd + 1.5))
-    V3Dt = @. V3Dt * (2^(2*id+jd + 1.5))
+    V3Dr = @. V3Dr * (2^(2 * id + jd + 1.5))
+    V3Ds = @. V3Ds * (2^(2 * id + jd + 1.5))
+    V3Dt = @. V3Dt * (2^(2 * id + jd + 1.5))
     return V3Dr, V3Ds, V3Dt
 end
 
-
-function equi_nodes(elem::Tet,N)
-    Np = (N+1)*(N+2)*(N+3) ÷ 6
-    r1D = LinRange(-1,1,N+1)
-    r,s,t = ntuple(x->zeros(Np),3)
+function equi_nodes(elem::Tet, N)
+    Np = (N + 1) * (N + 2) * (N + 3) ÷ 6
+    r1D = LinRange(-1, 1, N + 1)
+    r, s, t = ntuple(x -> zeros(Np), 3)
     sk = 1
-    for k = 0:N, j = 0:N-k, i = 0:N-j-k
-        r[sk] = r1D[i+1]
-        s[sk] = r1D[j+1]
-        t[sk] = r1D[k+1]
+    for k in 0:N, j in 0:(N - k), i in 0:(N - j - k)
+        r[sk] = r1D[i + 1]
+        s[sk] = r1D[j + 1]
+        t[sk] = r1D[k + 1]
         sk += 1
     end
 
-    return r,s,t
+    return r, s, t
 end
-
 
 """
     quad_nodes_tet(N)
@@ -91,21 +89,24 @@ end
 Returns quadrature nodes and weights which exactly integrate degree N polynomials
 """
 function quad_nodes_tet(N)
-
-    if N<16
-        rstw::Matrix{Float64} = readdlm(string(@__DIR__,"/QuadratureData/quad_nodes_tet_N", N, ".txt"),' ', Float64, '\n')
-        r = rstw[:,1]
-        s = rstw[:,2]
-        t = rstw[:,3]
-        w = rstw[:,4]
+    if N < 16
+        rstw::Matrix{Float64} = readdlm(string(@__DIR__, "/QuadratureData/quad_nodes_tet_N",
+                                               N, ".txt"),
+                                        ' ',
+                                        Float64,
+                                        '\n')
+        r = rstw[:, 1]
+        s = rstw[:, 2]
+        t = rstw[:, 3]
+        w = rstw[:, 4]
     elseif N < 21
         r, s, t, w = jaskowiec_sukumar_quad_nodes(Tet(), N)
     else
-        cubN = convert(Int,ceil((N+1)/2))
-        r,s,t,w = stroud_quad_nodes(Tet(),cubN)
+        cubN = convert(Int, ceil((N + 1) / 2))
+        r, s, t, w = stroud_quad_nodes(Tet(), cubN)
     end
 
-    return r,s,t,w
+    return r, s, t, w
 end
 
 """
@@ -120,62 +121,69 @@ function jaskowiec_sukumar_quad_nodes(elem::Tet, N)
         @error "Jaskowiek-Sukumar quadrature rules not available for N > 20."
     end
 
-    rstw::Matrix{Float64} = readdlm(string(@__DIR__,"/QuadratureData/jaskowiec_sukumar_nodes_tet_N", N, ".txt"), ' ', Float64, '\n')
+    rstw::Matrix{Float64} = readdlm(string(@__DIR__,
+                                           "/QuadratureData/jaskowiec_sukumar_nodes_tet_N",
+                                           N, ".txt"),
+                                    ' ',
+                                    Float64,
+                                    '\n')
 
-    return rstw[:,1], rstw[:,2], rstw[:,3], rstw[:,4]
+    return rstw[:, 1], rstw[:, 2], rstw[:, 3], rstw[:, 4]
 end
 
 function abctorst(::Tet, a, b, c)
-    r = @. .5 * (1+a) * .5 * (1-b) * (1-c) - 1
-    s = @. .5 * (1+b) * (1-c) - 1
+    r = @. 0.5 * (1 + a) * 0.5 * (1 - b) * (1 - c) - 1
+    s = @. 0.5 * (1 + b) * (1 - c) - 1
     t = copy(c)
     return r, s, t
 end
 
 function rsttoabc(::Tet, r, s, t)
-    a = @. 2 * (1+r) / (-s-t) - 1
-    b = @. 2 * (1+s) / (1-t) - 1
+    a = @. 2 * (1 + r) / (-s - t) - 1
+    b = @. 2 * (1 + s) / (1 - t) - 1
     c = copy(t)
     return a, b, c
 end
 
 function stroud_quad_nodes(elem::Tet, N)
-    cubA,cubWA = gauss_quad(0,0,N)
-    cubB,cubWB = gauss_quad(1,0,N)
-    cubC,cubWC = gauss_quad(2,0,N)
+    cubA, cubWA = gauss_quad(0, 0, N)
+    cubB, cubWB = gauss_quad(1, 0, N)
+    cubC, cubWC = gauss_quad(2, 0, N)
 
-    a,b,c = vec.(meshgrid(cubA,cubB,cubC))
-    wa,wb,wc = vec.(meshgrid(cubWA,cubWB,cubWC))
+    a, b, c = vec.(meshgrid(cubA, cubB, cubC))
+    wa, wb, wc = vec.(meshgrid(cubWA, cubWB, cubWC))
 
     r, s, t = abctorst(elem, a, b, c)
     w = @. wa * wb * wc
-    w = (4/3) * w ./ sum(w)
+    w = (4 / 3) * w ./ sum(w)
     return r, s, t, w
 end
 
 quad_nodes(elem::Tet, N) = quad_nodes_tet(2 * N)
 
 function basis(elem::Tet, N, r, s, t)
-    Np = (N+1) * (N+2) * (N+3) ÷ 6
+    Np = (N + 1) * (N + 2) * (N + 3) ÷ 6
 
     V, Vr, Vs, Vt = ntuple(x -> zeros(length(r), Np), 4)
-    
+
     a, b, c = rsttoabc(elem, r, s, t)
 
     tol = 1e-14
-    ida = @. abs(s+t) < tol
-    idb = @. abs(1-t) < tol
+    ida = @. abs(s + t) < tol
+    idb = @. abs(1 - t) < tol
     a[ida] .= -1
     b[idb] .= -1
 
     sk = 1
-    for i = 0:N
-        for j = 0:N-i
-            for k = 0:N-i-j
+    for i in 0:N
+        for j in 0:(N - i)
+            for k in 0:(N - i - j)
                 V[:, sk] .= simplex_3D(a, b, c, i, j, k)
                 # should have fewer allocations than previous implementation:
                 # `Vr[:,sk], Vs[:,sk], Vt[:,sk] = grad_simplex(...)`
-                map((out, x) -> out .= x, view.((Vr, Vs, Vt), :, sk), grad_simplex_3D(a, b, c, i, j, k))
+                map((out, x) -> out .= x,
+                    view.((Vr, Vs, Vt), :, sk),
+                    grad_simplex_3D(a, b, c, i, j, k))
                 sk += 1
             end
         end

--- a/src/tri_element.jl
+++ b/src/tri_element.jl
@@ -9,8 +9,8 @@ Evaluate 2D PKDO basis phi_ij at points (a,b) on the Duffy domain [-1,1]^2
 """
 function simplex_2D(a, b, i, j)
     h₁ = jacobiP(a, 0, 0, i)
-    h₂ = jacobiP(b, 2i+1, 0, j)
-    return @. sqrt(2.0)*h₁*h₂*(1-b)^i # WARNING: (1-b)^i can blow up if N is too large (> 25)
+    h₂ = jacobiP(b, 2i + 1, 0, j)
+    return @. sqrt(2.0) * h₁ * h₂ * (1 - b)^i # WARNING: (1-b)^i can blow up if N is too large (> 25)
 end
 
 """
@@ -22,31 +22,30 @@ indices (id,jd) at (a,b)
 
 function grad_simplex_2D(a, b, id, jd)
     fa = jacobiP(a, 0, 0, id)
-    gb = jacobiP(b, 2*id+1, 0, jd)
+    gb = jacobiP(b, 2 * id + 1, 0, jd)
     dfa = grad_jacobiP(a, 0, 0, id)
-    dgb = grad_jacobiP(b, 2*id+1, 0, jd)
+    dgb = grad_jacobiP(b, 2 * id + 1, 0, jd)
 
-    dmodedr = @. dfa*gb
+    dmodedr = @. dfa * gb
     if id > 0
-        dmodedr = dmodedr.*((0.5*(1 .- b)).^(id-1))
+        dmodedr = dmodedr .* ((0.5 * (1 .- b)) .^ (id - 1))
     end
 
-    dmodeds = @. dfa*(gb*(0.5*(1+a)))
+    dmodeds = @. dfa * (gb * (0.5 * (1 + a)))
     if id > 0
-        dmodeds = dmodeds.*((0.5*(1 .- b)).^(id-1))
+        dmodeds = dmodeds .* ((0.5 * (1 .- b)) .^ (id - 1))
     end
 
-    tmp = @. dgb*((0.5*(1-b))^id)
+    tmp = @. dgb * ((0.5 * (1 - b))^id)
     if id > 0
-        tmp = tmp-0.5*id*gb.*((0.5*(1 .- b)).^(id-1))
+        tmp = tmp - 0.5 * id * gb .* ((0.5 * (1 .- b)) .^ (id - 1))
     end
-    dmodeds = dmodeds+fa.*tmp
+    dmodeds = dmodeds + fa .* tmp
 
-    dmodedr = 2^(id+0.5)*dmodedr
-    dmodeds = 2^(id+0.5)*dmodeds
+    dmodedr = 2^(id + 0.5) * dmodedr
+    dmodeds = 2^(id + 0.5) * dmodeds
     return dmodedr, dmodeds
 end
-
 
 """
     rstoab(r, s, tol = 1e-12)
@@ -87,14 +86,17 @@ end
 Returns quadrature nodes (from Gimbutas and Xiao 2010) which exactly integrate degree N polynomials
 """
 function quad_nodes_tri(N)
-
     if N < 51
-        rsw::Matrix{Float64} = readdlm(string(@__DIR__, "/QuadratureData/quad_nodes_tri_N", N, ".txt"), ' ', Float64, '\n')
+        rsw::Matrix{Float64} = readdlm(string(@__DIR__, "/QuadratureData/quad_nodes_tri_N",
+                                              N, ".txt"),
+                                       ' ',
+                                       Float64,
+                                       '\n')
         r = rsw[:, 1]
         s = rsw[:, 2]
         w = rsw[:, 3]
     else
-        cubN = ceil(Int, (N+1) / 2)
+        cubN = ceil(Int, (N + 1) / 2)
         r, s, w = stroud_quad_nodes(Tri(), cubN)
     end
 
@@ -113,12 +115,12 @@ function stroud_quad_nodes(::Tri, N)
 end
 
 function equi_nodes(::Tri, N)
-    Np = (N+1) * (N+2) ÷ 2
+    Np = (N + 1) * (N + 2) ÷ 2
 
     r = zeros(Np)
     s = zeros(Np)
 
-    r1D = LinRange(-1, 1, N+1)
+    r1D = LinRange(-1, 1, N + 1)
     sk = 1
 
     # order so that the nodes change fastest in the x-direction,
@@ -128,27 +130,26 @@ function equi_nodes(::Tri, N)
     # | \
     # 1---2
 
-    for j = 0:N, i = 0:N-j 
-        r[sk] = r1D[i+1]
-        s[sk] = r1D[j+1]
+    for j in 0:N, i in 0:(N - j)
+        r[sk] = r1D[i + 1]
+        s[sk] = r1D[j + 1]
         sk += 1
     end
 
     return r[:], s[:]
 end
 
-
-function quad_nodes(::Tri, N)    
-    return quad_nodes_tri(2*N)
+function quad_nodes(::Tri, N)
+    return quad_nodes_tri(2 * N)
 end
 
 function basis(::Tri, N, r, s)
-    Np = (N+1) * (N+2) ÷ 2
+    Np = (N + 1) * (N + 2) ÷ 2
     V2D, V2Dr, V2Ds = ntuple(x -> zeros(length(r), Np), 3)
     a, b = rstoab(r, s)
     sk = 1
-    for i = 0:N
-        for j = 0:N-i
+    for i in 0:N
+        for j in 0:(N - i)
             V2D[:, sk] = simplex_2D(a, b, i, j)
             V2Dr[:, sk], V2Ds[:, sk] = grad_simplex_2D(a, b, i, j)
             sk = sk + 1

--- a/src/warpblend_interp_nodes.jl
+++ b/src/warpblend_interp_nodes.jl
@@ -10,9 +10,23 @@ Returns list of edges for a specific element (elem = Tri(), Pyr(), Hex(), or Tet
 """
 get_edge_list(elem::AbstractElemShape)
 
-get_edge_list(elem::Union{Tri, Quad}) = SVector{2}.(find_face_nodes(elem, equi_nodes(elem, 1)...))
-get_edge_list(::Tet)  = SVector(1, 4), SVector(4, 3), SVector(3, 1), SVector(1, 2), SVector(3, 2), SVector(4, 2)
-get_edge_list(::Pyr)  = SVector(1, 2), SVector(2, 4), SVector(3, 4), SVector(3, 1), SVector(1, 5), SVector(2, 5), SVector(3, 5), SVector(4, 5)
+function get_edge_list(elem::Union{Tri, Quad})
+    SVector{2}.(find_face_nodes(elem, equi_nodes(elem, 1)...))
+end
+function get_edge_list(::Tet)
+    SVector(1, 4), SVector(4, 3), SVector(3, 1), SVector(1, 2), SVector(3, 2), SVector(4,
+                                                                                       2)
+end
+function get_edge_list(::Pyr)
+    SVector(1, 2),
+    SVector(2, 4),
+    SVector(3, 4),
+    SVector(3, 1),
+    SVector(1, 5),
+    SVector(2, 5),
+    SVector(3, 5),
+    SVector(4, 5)
+end
 
 # edges = recursive ±xyz ordering on each face
 # 
@@ -22,20 +36,31 @@ get_edge_list(::Pyr)  = SVector(1, 2), SVector(2, 4), SVector(3, 4), SVector(3, 
 # | 2 ___| 4
 # |/     |/ 
 # 1 ---- 3      
- 
-get_edge_list(::Hex) = SVector(1, 5), SVector(3, 7), SVector(2, 6), SVector(4, 8), 
-                       SVector(1, 3), SVector(2, 4), SVector(1, 2), SVector(3, 4), 
-                       SVector(5, 7), SVector(6, 8), SVector(5, 6), SVector(7, 8)
 
+function get_edge_list(::Hex)
+    SVector(1, 5),
+    SVector(3, 7),
+    SVector(2, 6),
+    SVector(4, 8),
+    SVector(1, 3),
+    SVector(2, 4),
+    SVector(1, 2),
+    SVector(3, 4),
+    SVector(5, 7),
+    SVector(6, 8),
+    SVector(5, 6),
+    SVector(7, 8)
+end
 
 get_vertices(elem::AbstractElemShape) = equi_nodes(elem, 1)
-get_vertex_fxns(elem::AbstractElemShape) =
+function get_vertex_fxns(elem::AbstractElemShape)
     (rst...) -> vandermonde(elem, 1, rst...) / vandermonde(elem, 1, equi_nodes(elem, 1)...)
+end
 
 # assumes r1D in [-1,1], v1, v2 are vertices
 function interp_1D_to_line(r1D, v1, v2)
     runit = @. (1 + r1D) / 2
-    return map((a,b) -> (b-a) * runit .+ a, v1, v2)
+    return map((a, b) -> (b - a) * runit .+ a, v1, v2)
 end
 
 """
@@ -66,7 +91,12 @@ function edge_basis(elem::AbstractElemShape, N, rst...)
     vertices = get_vertices(elem)
     edges = get_edge_list(elem)
     vertex_functions = get_vertex_fxns(elem)
-    return edge_basis(N, vertices, edges, (N, r)->basis(Line(), N, r), vertex_functions, rst...)
+    return edge_basis(N,
+                      vertices,
+                      edges,
+                      (N, r) -> basis(Line(), N, r),
+                      vertex_functions,
+                      rst...)
 end
 
 """
@@ -80,15 +110,15 @@ function edge_basis(N, vertices, edges, basis1D, vertex_functions, rst...)
         return V1
     end
 
-    V = zeros(length(first(rst)), length(edges) * (N-1) + length(first(vertices)))
-    V[:,1:size(V1, 2)] .= V1 # initialize vertex functions
+    V = zeros(length(first(rst)), length(edges) * (N - 1) + length(first(vertices)))
+    V[:, 1:size(V1, 2)] .= V1 # initialize vertex functions
 
-    id = size(V1,2) + 1
+    id = size(V1, 2) + 1
     for e in edges
         # edge parametrization from paper:
         # "A Comparison of High-Order Interpolation Nodes for the Pyramid"
-        r1D_edge = V1[:,e[1]] - V1[:,e[2]]
-        V1D, _ = basis1D(N-2, r1D_edge)
+        r1D_edge = V1[:, e[1]] - V1[:, e[2]]
+        V1D, _ = basis1D(N - 2, r1D_edge)
         for i in axes(V1D, 2)
             V[:, id] = V1D[:, i] .* V1[:, e[1]] .* V1[:, e[2]]
             id += 1
@@ -104,14 +134,14 @@ end
 Given volume nodes `r`, `s`, `t`, finds face nodes. Note that this function implicitly
 defines an ordering on the faces.
 """
-function find_face_nodes(::Tri, r, s, tol=50*eps())
+function find_face_nodes(::Tri, r, s, tol = 50 * eps())
     e1 = findall(@. abs(s + 1) < tol)
     e2 = findall(@. abs(r + s) < tol)
     e3 = findall(@. abs(r + 1) < tol)
     return e1, e2, reverse(e3)
 end
 
-function find_face_nodes(::Quad, r, s, tol=50*eps())
+function find_face_nodes(::Quad, r, s, tol = 50 * eps())
     e1 = findall(@. abs(r + 1) < tol)
     e2 = findall(@. abs(r - 1) < tol)
     e3 = findall(@. abs(s + 1) < tol)
@@ -119,7 +149,7 @@ function find_face_nodes(::Quad, r, s, tol=50*eps())
     return e1, e2, e3, e4
 end
 
-function find_face_nodes(::Hex, r, s, t, tol=50*eps())
+function find_face_nodes(::Hex, r, s, t, tol = 50 * eps())
     fv1 = findall(@. abs(r + 1) < tol)
     fv2 = findall(@. abs(r - 1) < tol)
     fv3 = findall(@. abs(s + 1) < tol)
@@ -129,7 +159,7 @@ function find_face_nodes(::Hex, r, s, t, tol=50*eps())
     return fv1, fv2, fv3, fv4, fv5, fv6
 end
 
-function find_face_nodes(::Tet, r, s, t, tol=50*eps())
+function find_face_nodes(::Tet, r, s, t, tol = 50 * eps())
     fv1 = findall(@. abs(s + 1) < tol)
     fv2 = findall(@. abs(r + s + t + 1) < tol)
     fv3 = findall(@. abs(r + 1) < tol)
@@ -139,7 +169,7 @@ end
 
 # Faces are ordered as described in "Coarse mesh partitioning for tree based AMR" 
 # by Burstedde and Holke (2018). https://arxiv.org/pdf/1611.02929.pdf
-function find_face_nodes(::Wedge, r, s, t, tol=50*eps())
+function find_face_nodes(::Wedge, r, s, t, tol = 50 * eps())
     fv1 = findall(@. abs(s + 1) < tol)  # first quad face
     fv2 = findall(@. abs(r + s) < tol)  # second quad face
     fv3 = findall(@. abs(r + 1) < tol)  # third quad face
@@ -148,11 +178,11 @@ function find_face_nodes(::Wedge, r, s, t, tol=50*eps())
     return fv1, fv2, fv3, fv4, fv5
 end
 
-function find_face_nodes(::Pyr, r, s, t, tol=50*eps())
+function find_face_nodes(::Pyr, r, s, t, tol = 50 * eps())
     fv1 = findall(@. abs(r + 1) < tol)  # +/- r tri faces
-    fv2 = findall(@. abs(r + t) < tol)   
+    fv2 = findall(@. abs(r + t) < tol)
     fv3 = findall(@. abs(s + 1) < tol)  # +/- s tri faces
-    fv4 = findall(@. abs(s + t) < tol)  
+    fv4 = findall(@. abs(s + t) < tol)
     fv5 = findall(@. abs(t + 1) < tol)  # bottom quad face
     return fv1, fv2, fv3, fv4, fv5
 end
@@ -173,7 +203,7 @@ num_vertices(::Tet) = 4
 num_faces(::Tet) = 4
 face_type(::Tet) = Tri()
 # 3 edges per face * (N-1) nodes per edge, 3 vertices
-num_face_only_nodes(::Tet, N) = max(0, (N + 1) * (N + 2) ÷ 2 - (3 * (N-1) + 3)) 
+num_face_only_nodes(::Tet, N) = max(0, (N + 1) * (N + 2) ÷ 2 - (3 * (N - 1) + 3))
 
 function pointwise_product_of_columns(A)
     a = ones(size(A, 1))
@@ -185,14 +215,13 @@ end
 
 # 3D face basis
 function face_basis(elem, N, r, s, t)
-
     if (elem isa Wedge) || (elem isa Pyr)
         @error "Face bases for wedges and pyramids not yet supported"
     end
-        
-    V_edge = edge_basis(elem, N, r, s, t)    
+
+    V_edge = edge_basis(elem, N, r, s, t)
     if (N < 2 && elem isa Hex) || (N < 3 && elem isa Tet)
-        return V_edge    
+        return V_edge
     end
 
     # initialize vertex and edge basis functions
@@ -208,14 +237,14 @@ function face_basis(elem, N, r, s, t)
         # compute face coordinates as a barycentric combo of reference vertices
         rf = sum([V1[:, fids[i]] * r1[i] for i in eachindex(r1, s1)])
         sf = sum([V1[:, fids[i]] * s1[i] for i in eachindex(r1, s1)])
-        
+
         # extend face polynomials linearly
         linear_face_basis = pointwise_product_of_columns(V1[:, fids])
         if elem isa Hex
-            V_face = vandermonde(face_type(elem), N-2, rf, sf)
+            V_face = vandermonde(face_type(elem), N - 2, rf, sf)
         elseif elem isa Tet
-            V_face = vandermonde(face_type(elem), N-3, rf, sf)
-        end 
+            V_face = vandermonde(face_type(elem), N - 3, rf, sf)
+        end
         for i in axes(V_face, 2)
             @. V[:, id] = V_face[:, i] * linear_face_basis
             id += 1
@@ -236,10 +265,10 @@ function build_warped_nodes(elem::AbstractElemShape, N, r1D)
     r1D_equi = equi_nodes(Line(), N)
     rst_edge_equi = interp_1D_to_edges(elem, r1D_equi)
     V_edge = edge_basis(elem, N, rst_edge_equi...)
-    rst_edge = interp_1D_to_edges(elem,r1D)
+    rst_edge = interp_1D_to_edges(elem, r1D)
 
-    c = (x->V_edge \ x).(rst_edge) # should be lsq solve
+    c = (x -> V_edge \ x).(rst_edge) # should be lsq solve
 
     rst_equi = equi_nodes(elem, N)
-    return (x->edge_basis(elem, N, rst_equi...) * x).(c)
+    return (x -> edge_basis(elem, N, rst_equi...) * x).(c)
 end

--- a/src/wedge_element.jl
+++ b/src/wedge_element.jl
@@ -5,44 +5,42 @@
 function basis(::Wedge, N, r, s, t)
     V_tri, Vr_tri, Vs_tri = basis(Tri(), N, r, s)
     V_1D, Vt_1D = basis(Line(), N, t)
-    Np = (N+1) * (N+2) * (N+1) ÷ 2
-    V, Vr, Vs, Vt = ntuple(x->zeros(length(r), Np), 4)
+    Np = (N + 1) * (N + 2) * (N + 1) ÷ 2
+    V, Vr, Vs, Vt = ntuple(x -> zeros(length(r), Np), 4)
     id = 1
     for j in axes(V_1D, 2)
         for i in axes(V_tri, 2)
-            @. V[:,id]  = V_tri[:,i]  * V_1D[:,j]
-            @. Vr[:,id] = Vr_tri[:,i] * V_1D[:,j]
-            @. Vs[:,id] = Vs_tri[:,i] * V_1D[:,j]
-            @. Vt[:,id] = V_tri[:,i]  * Vt_1D[:,j]
+            @. V[:, id] = V_tri[:, i] * V_1D[:, j]
+            @. Vr[:, id] = Vr_tri[:, i] * V_1D[:, j]
+            @. Vs[:, id] = Vs_tri[:, i] * V_1D[:, j]
+            @. Vt[:, id] = V_tri[:, i] * Vt_1D[:, j]
             id += 1
         end
     end
-    return V,Vr,Vs,Vt
+    return V, Vr, Vs, Vt
 end
 
-function equi_nodes(::Wedge,N)
-    t1D = LinRange(-1, 1, N+1)
+function equi_nodes(::Wedge, N)
+    t1D = LinRange(-1, 1, N + 1)
     r_tri, s_tri = equi_nodes(Tri(), N)
     t, r = vec.(meshgrid(t1D, r_tri))
-    _, s = vec.(meshgrid(t1D, s_tri))    
-    return r,s,t
+    _, s = vec.(meshgrid(t1D, s_tri))
+    return r, s, t
 end
-
 
 function nodes(::Wedge, N)
     t1D, _ = gauss_lobatto_quad(0, 0, N)
     r_tri, s_tri = nodes(Tri(), N)
     t, r = vec.(meshgrid(t1D, r_tri))
-    _, s = vec.(meshgrid(t1D, s_tri))    
-    return r,s,t
+    _, s = vec.(meshgrid(t1D, s_tri))
+    return r, s, t
 end
-
 
 function quad_nodes(::Wedge, N)
     r_tri, s_tri, w_tri = quad_nodes(Tri(), N)
     t1D, wt1D = quad_nodes(Line(), N)
     wt, wrs = vec.(meshgrid(wt1D, w_tri))
     t, r = vec.(meshgrid(t1D, r_tri))
-    _, s = vec.(meshgrid(t1D, s_tri))  
+    _, s = vec.(meshgrid(t1D, s_tri))
     return r, s, t, wrs .* wt
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,36 +3,36 @@ using Test
 using LinearAlgebra
 
 @testset "1D tests" begin
-    tol = 1e2*eps()
+    tol = 1e2 * eps()
 
     N = 0
-    r,w = gauss_lobatto_quad(0,0,N)
+    r, w = gauss_lobatto_quad(0, 0, N)
     @test sum(w) ≈ 2
 
-    for N = 1:2
-        r,w = gauss_quad(0,0,N)
+    for N in 1:2
+        r, w = gauss_quad(0, 0, N)
         @test sum(w) ≈ 2
-        @test abs(sum(w.*r)) < tol
+        @test abs(sum(w .* r)) < tol
 
-        V = vandermonde(Line(),N,r)
-        @test V'*diagm(w)*V ≈ I
+        V = vandermonde(Line(), N, r)
+        @test V' * diagm(w) * V ≈ I
 
-        Vr = grad_vandermonde(Line(),N,r)
-        Dr = Vr/V
-        @test norm(sum(Dr,dims=2)) < tol
-        @test Dr*r ≈ ones(N+1)
+        Vr = grad_vandermonde(Line(), N, r)
+        Dr = Vr / V
+        @test norm(sum(Dr, dims = 2)) < tol
+        @test Dr * r ≈ ones(N + 1)
 
-        r,w = gauss_lobatto_quad(0,0,N)
+        r, w = gauss_lobatto_quad(0, 0, N)
         @test sum(w) ≈ 2
-        @test abs(sum(w.*r)) < tol
+        @test abs(sum(w .* r)) < tol
 
         # check if Lobatto is exact for 2N-2 polynoms
-        V = vandermonde(Line(),N-1,r)
-        @test V'*diagm(w)*V ≈ I
+        V = vandermonde(Line(), N - 1, r)
+        @test V' * diagm(w) * V ≈ I
 
-        Dr = grad_vandermonde(Line(),N,r)/vandermonde(Line(),N,r)
-        @test norm(sum(Dr,dims=2)) < tol
-        @test Dr*r ≈ ones(N+1)
+        Dr = grad_vandermonde(Line(), N, r) / vandermonde(Line(), N, r)
+        @test norm(sum(Dr, dims = 2)) < tol
+        @test Dr * r ≈ ones(N + 1)
     end
 
     @test NodesAndModes.face_vertices(Line()) == (1, 2)
@@ -42,31 +42,30 @@ area(elem::Quad) = 4.0
 area(elem::Tri) = 2.0
 
 @testset "2D $elem basis tests" for elem in (Tri(), Quad())
-
-    tol = 1e2*eps()
+    tol = 1e2 * eps()
 
     N = 3
     rq, sq, wq = quad_nodes(elem, N)
-    @test sum(wq) ≈ area(elem) 
+    @test sum(wq) ≈ area(elem)
 
     Vq = vandermonde(elem, N, rq, sq)
     @test Vq' * diagm(wq) * Vq ≈ I
 
     r, s = nodes(elem, N)
     V = vandermonde(elem, N, r, s)
-    Dr, Ds = (A->A / V).(grad_vandermonde(elem, N, r, s))
-    @test norm(sum(Dr, dims=2)) + norm(sum(Ds, dims=2)) < tol
+    Dr, Ds = (A -> A / V).(grad_vandermonde(elem, N, r, s))
+    @test norm(sum(Dr, dims = 2)) + norm(sum(Ds, dims = 2)) < tol
     @test norm(Dr * s) + norm(Ds * r) < tol
     @test Dr * r ≈ ones(length(r))
     @test Ds * s ≈ ones(length(s))
 
     r, s = equi_nodes(elem, N)
     V = vandermonde(elem, N, r, s)
-    Dr,Ds = (A->A / V).(grad_vandermonde(elem, N, r, s))
-    @test norm(sum(Dr, dims=2)) + norm(sum(Ds, dims=2)) < tol
+    Dr, Ds = (A -> A / V).(grad_vandermonde(elem, N, r, s))
+    @test norm(sum(Dr, dims = 2)) + norm(sum(Ds, dims = 2)) < tol
     @test norm(Dr * s) + norm(Ds * r) < tol
-    @test Dr*r ≈ ones(length(r))
-    @test Ds*s ≈ ones(length(s))
+    @test Dr * r ≈ ones(length(r))
+    @test Ds * s ≈ ones(length(s))
 
     # elem is either a tri or quad type
     num_faces = (elem == Tri()) ? 3 : 4
@@ -92,7 +91,8 @@ area(elem::Tri) = 2.0
         Vq1D = vandermonde(Line(), N, quad_nodes(Line(), N)[1])
         @test Vq ≈ kron(Vq1D, Vq1D)
 
-        @test NodesAndModes.face_basis(Quad(), N, r, s) ≈ NodesAndModes.edge_basis(Quad(), N, r, s)
+        @test NodesAndModes.face_basis(Quad(), N, r, s) ≈
+              NodesAndModes.edge_basis(Quad(), N, r, s)
 
         # check invertibility of face basis matrix
         Fmask = hcat(NodesAndModes.find_face_nodes(Quad(), r, s)...)
@@ -102,8 +102,8 @@ end
 
 volume(elem::Hex) = 8
 volume(elem::Wedge) = 4
-volume(elem::Pyr) = 8/3
-volume(elem::Tet) = 4/3
+volume(elem::Pyr) = 8 / 3
+volume(elem::Tet) = 4 / 3
 
 num_faces(::Tet) = 4
 num_faces(::Wedge) = 5
@@ -111,13 +111,12 @@ num_faces(::Pyr) = 5
 num_faces(::Hex) = 6
 
 @testset "3D $elem basis tests" for elem in (Hex(), Wedge(), Pyr(), Tet())
-
     tol = 5e2 * eps()
 
     N = 3
-    rq, sq, tq, wq = quad_nodes(elem,N)
+    rq, sq, tq, wq = quad_nodes(elem, N)
     @test sum(wq) ≈ volume(elem)
-    if elem==Hex()
+    if elem == Hex()
         @test abs(sum(rq .* wq)) + abs(sum(sq .* wq)) + abs(sum(tq .* wq)) < tol
     end
 
@@ -129,8 +128,9 @@ num_faces(::Hex) = 6
     if elem != Pyr()
         r, s, t = nodes(elem, N)
         V = vandermonde(elem, N, r, s, t)
-        Dr, Ds, Dt = (A->A / V).(grad_vandermonde(elem, N, r, s, t))
-        @test norm(sum(Dr, dims=2)) + norm(sum(Ds, dims=2)) + norm(sum(Dt, dims=2)) < tol
+        Dr, Ds, Dt = (A -> A / V).(grad_vandermonde(elem, N, r, s, t))
+        @test norm(sum(Dr, dims = 2)) + norm(sum(Ds, dims = 2)) + norm(sum(Dt, dims = 2)) <
+              tol
         @test norm(Dr * s) + norm(Dr * t) < tol
         @test norm(Ds * r) + norm(Ds * t) < tol
         @test norm(Dt * r) + norm(Dt * s) < tol
@@ -140,25 +140,32 @@ num_faces(::Hex) = 6
 
         r, s, t = equi_nodes(elem, N)
         V = vandermonde(elem, N, r, s, t)
-        Dr, Ds, Dt = (A->A / V).(grad_vandermonde(elem, N, r, s, t))
-        @test norm(sum(Dr, dims=2)) + norm(sum(Ds, dims=2)) + norm(sum(Dt, dims=2)) < tol
-        @test norm(Dr * s) + norm(Dr * t) + norm(Ds * r) + norm(Ds * t) + norm(Dt * r) + norm(Dt * s) < tol
+        Dr, Ds, Dt = (A -> A / V).(grad_vandermonde(elem, N, r, s, t))
+        @test norm(sum(Dr, dims = 2)) + norm(sum(Ds, dims = 2)) + norm(sum(Dt, dims = 2)) <
+              tol
+        @test norm(Dr * s) +
+              norm(Dr * t) +
+              norm(Ds * r) +
+              norm(Ds * t) +
+              norm(Dt * r) +
+              norm(Dt * s) < tol
         @test Dr * r ≈ one.(r)
         @test Ds * s ≈ one.(s)
-        @test Dt * t ≈ one.(t)   
-        
+        @test Dt * t ≈ one.(t)
+
     elseif elem == Pyr()
         r, s, t = nodes(elem, N)
-        rq, sq, tq, wq = quad_nodes(elem, N)        
-        Vq, Vr, Vs, Vt = (A -> A / vandermonde(elem, N, r, s, t)).(basis(elem, N, rq, sq, tq))
+        rq, sq, tq, wq = quad_nodes(elem, N)
+        Vq, Vr, Vs, Vt = (A -> A / vandermonde(elem, N, r, s, t)).(basis(elem, N, rq, sq,
+                                                                         tq))
         M = Vq' * diagm(wq) * Vq
 
         # construct weak differentiation matrices instead of nodal differentiation matrices since 
         # the pyramid basis is singular at the node at the tip of the pyramid. 
         Dr, Ds, Dt = (A -> M \ (Vq' * diagm(wq) * A)).((Vr, Vs, Vt))
-        @test norm(sum(Dr, dims=2)) < tol
-        @test norm(sum(Ds, dims=2)) < tol
-        @test norm(sum(Dt, dims=2)) < tol
+        @test norm(sum(Dr, dims = 2)) < tol
+        @test norm(sum(Ds, dims = 2)) < tol
+        @test norm(sum(Dt, dims = 2)) < tol
         @test norm(Dr * s) + norm(Dr * t) < tol
         @test norm(Ds * r) + norm(Ds * t) < tol
         @test norm(Dt * r) + norm(Dt * s) < tol
@@ -168,19 +175,19 @@ num_faces(::Hex) = 6
 
         a, b, c = NodesAndModes.rsttoabc(Pyr(), rq, sq, tq)
         r2, s2, t2 = NodesAndModes.abctorst(Pyr(), a, b, c)
-        @test r2 ≈ rq 
-        @test s2 ≈ sq 
-        @test t2 ≈ tq 
+        @test r2 ≈ rq
+        @test s2 ≈ sq
+        @test t2 ≈ tq
     end
 end
 
 # these can be used for transfinite interpolation
 @testset "3D face bases (no interior nodes)" begin
-
     r, s, t = equi_nodes(Hex(), 3)
     @test size(NodesAndModes.face_basis(Hex(), 2, r, s, t), 2) == 26
     r, s, t = equi_nodes(Tet(), 3)
-    @test NodesAndModes.face_basis(Tet(), 2, r, s, t) ≈ NodesAndModes.edge_basis(Tet(), 2, r, s, t)
+    @test NodesAndModes.face_basis(Tet(), 2, r, s, t) ≈
+          NodesAndModes.edge_basis(Tet(), 2, r, s, t)
 
     @test_throws MethodError NodesAndModes.face_basis(Wedge(), 3, equi_nodes(Wedge(), 4)...)
     @test_throws MethodError NodesAndModes.face_basis(Pyr(), 3, equi_nodes(Pyr(), 4)...)
@@ -200,69 +207,74 @@ end
 end
 
 @testset "Test for Kronecker structure in the Hex basis matrix" begin
-    tol = 5e2*eps()
+    tol = 5e2 * eps()
     N = 3
     VDM_1D = vandermonde(Line(), N, nodes(Line(), N))
     VDM_quad_1D = vandermonde(Line(), N, quad_nodes(Line(), N)[1])
-    @test abs(norm(vandermonde(Hex(), N, nodes(Hex(), N)...) - kron(VDM_1D, VDM_1D, VDM_1D))) < tol
-    @test abs(norm(vandermonde(Hex(), N, quad_nodes(Hex(), N)[1:3]...) - kron(VDM_quad_1D, VDM_quad_1D, VDM_quad_1D))) < tol
+    @test abs(norm(vandermonde(Hex(), N, nodes(Hex(), N)...) - kron(VDM_1D, VDM_1D, VDM_1D))) <
+          tol
+    @test abs(norm(vandermonde(Hex(), N, quad_nodes(Hex(), N)[1:3]...) -
+                   kron(VDM_quad_1D, VDM_quad_1D, VDM_quad_1D))) < tol
 end
 
 # test high order symmetric quadrature rules
 @testset "Simplicial symmetric quadrature" begin
-    tol = 1e3*eps()
+    tol = 1e3 * eps()
 
     N = 14
     rq, sq, wq = quad_nodes(Tri(), N)
     @test sum(wq) ≈ 2
-    @test sum(rq .* wq) ≈ -2/3
-    @test sum(sq .* wq) ≈ -2/3
+    @test sum(rq .* wq) ≈ -2 / 3
+    @test sum(sq .* wq) ≈ -2 / 3
 
     N = 8
     rq, sq, tq, wq = quad_nodes(Tet(), N)
-    @test sum(wq) ≈ 4/3
-    @test sum(rq .* wq) ≈ -2/3
-    @test sum(sq .* wq) ≈ -2/3
-    @test sum(tq .* wq) ≈ -2/3
+    @test sum(wq) ≈ 4 / 3
+    @test sum(rq .* wq) ≈ -2 / 3
+    @test sum(sq .* wq) ≈ -2 / 3
+    @test sum(tq .* wq) ≈ -2 / 3
 end
 
 # test high order Stroud quadrature
 @testset "Simplicial Stroud quadrature" begin
-    tol = 1e3*eps()    
+    tol = 1e3 * eps()
 
     N = 26
     rq, sq, wq = quad_nodes(Tri(), N)
     @test sum(wq) ≈ 2
-    @test sum(rq .* wq) ≈ -2/3
-    @test sum(sq .* wq) ≈ -2/3
+    @test sum(rq .* wq) ≈ -2 / 3
+    @test sum(sq .* wq) ≈ -2 / 3
 
     N = 11
     rq, sq, tq, wq = quad_nodes(Tet(), N)
-    @test sum(wq) ≈ 4/3
-    @test sum(rq .* wq) ≈ -2/3
-    @test sum(sq .* wq) ≈ -2/3
-    @test sum(tq .* wq) ≈ -2/3
+    @test sum(wq) ≈ 4 / 3
+    @test sum(rq .* wq) ≈ -2 / 3
+    @test sum(sq .* wq) ≈ -2 / 3
+    @test sum(tq .* wq) ≈ -2 / 3
 
     @test_throws ArgumentError jaskowiec_sukumar_quad_nodes(Tet(), 21)
 end
 
 # apparently inference got better after 1.5 but breaks in nightly
-if VERSION >= v"1.6" && VERSION <= v"1.9" 
+if VERSION >= v"1.6" && VERSION <= v"1.9"
     @testset "Inferrability tests" begin
         for elementType in (Line(), Tri(), Quad(), Tet(), Pyr(), Wedge(), Hex())
             N = 1
             if elementType == Line()
-                @test_nowarn (@inferred gauss_quad(0, 0, N)) == ([-0.5773502691896257, 0.5773502691896257], [0.9999999999999998, 0.9999999999999998])
-                @test_nowarn (@inferred gauss_lobatto_quad(0, 0, N)) == ([-1.0, 1.0], [1.0, 1.0])
+                @test_nowarn (@inferred gauss_quad(0, 0, N)) ==
+                             ([-0.5773502691896257, 0.5773502691896257],
+                              [0.9999999999999998, 0.9999999999999998])
+                @test_nowarn (@inferred gauss_lobatto_quad(0, 0, N)) ==
+                             ([-1.0, 1.0], [1.0, 1.0])
             end
-            
+
             @test_nowarn @inferred nodes(elementType, N)
             @test_nowarn @inferred quad_nodes(elementType, N)
             @test_nowarn @inferred equi_nodes(elementType, N)
             if elementType == Line()
-                @test_nowarn @inferred basis(elementType, N, nodes(elementType,N))
+                @test_nowarn @inferred basis(elementType, N, nodes(elementType, N))
             else
-                @test_nowarn @inferred basis(elementType, N, nodes(elementType,N)...)
+                @test_nowarn @inferred basis(elementType, N, nodes(elementType, N)...)
             end
         end
     end


### PR DESCRIPTION
Added .JuliaFormatter.toml file (copied from Trixi.jl). Assumes v1.0.60 of JuliaFormatter.jl at the moment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily formatter-driven whitespace/syntax normalization with no intended algorithm changes; risk is limited to accidental semantic shifts from refactoring-like rewrites.
> 
> **Overview**
> Adds `.JuliaFormatter.toml` (SciML style + alignment options) and reformats the codebase to match JuliaFormatter.jl v1.0.60 output.
> 
> Updates `docs/make.jl`, core element/basis implementations, warp/blend node utilities, and `runtests.jl` with whitespace/indentation and minor syntax normalization (e.g., `for … in`, spacing, line breaks) without intended behavioral changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e66b263fbd6b5b35fa990e16e7a286bbe2e404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->