### PR TITLE
Introduce AbstractTensorProductElement and AbstractSimplex types

### DIFF
--- a/src/NodesAndModes.jl
+++ b/src/NodesAndModes.jl
@@ -9,11 +9,15 @@ include("meshgrid.jl")
 
 # each type of element shape - used for dispatch only
 abstract type AbstractElemShape{NDIMS} end
-struct Line <: AbstractElemShape{1} end
-struct Quad <: AbstractElemShape{2} end
-struct Tri <: AbstractElemShape{2} end
-struct Hex <: AbstractElemShape{3} end
-struct Tet <: AbstractElemShape{3} end
+
+abstract type AbstractTensorProductElement{NDIMS} <: AbstractElemShape{NDIMS} end
+struct Line <: AbstractTensorProductElement{1} end
+struct Quad <: AbstractTensorProductElement{2} end
+struct Hex <: AbstractTensorProductElement{3} end
+
+abstract type AbstractSimplexElement{NDIMS} <: AbstractElemShape{NDIMS} end
+struct Tri <: AbstractSimplexElement{2} end
+struct Tet <: AbstractSimplexElement{3} end
 
 # `node_ids_by_face` is an optional container for node ids of each face, since there is more than
 # one face type for both Wedge and Pyramid types.
@@ -28,6 +32,7 @@ end
 Pyr() = Pyr(nothing)
 
 export AbstractElemShape
+export AbstractTensorProductElement, AbstractSimplexElement
 export Line
 export Tri, Quad
 export Hex, Wedge, Pyr, Tet

--- a/src/NodesAndModes.jl
+++ b/src/NodesAndModes.jl
@@ -8,31 +8,34 @@ using StaticArrays: SVector
 include("meshgrid.jl")
 
 # each type of element shape - used for dispatch only
-abstract type AbstractElemShape{NDIMS} end
+abstract type AbstractElementShape{NDIMS} end
 
-abstract type AbstractTensorProductElement{NDIMS} <: AbstractElemShape{NDIMS} end
+abstract type AbstractTensorProductElement{NDIMS} <: AbstractElementShape{NDIMS} end
 struct Line <: AbstractTensorProductElement{1} end
 struct Quad <: AbstractTensorProductElement{2} end
 struct Hex <: AbstractTensorProductElement{3} end
 
-abstract type AbstractSimplexElement{NDIMS} <: AbstractElemShape{NDIMS} end
+abstract type AbstractSimplexElement{NDIMS} <: AbstractElementShape{NDIMS} end
 struct Tri <: AbstractSimplexElement{2} end
 struct Tet <: AbstractSimplexElement{3} end
 
 # `node_ids_by_face` is an optional container for node ids of each face, since there is more than
 # one face type for both Wedge and Pyramid types.
-struct Wedge{T} <: AbstractElemShape{3}
+struct Wedge{T} <: AbstractElementShape{3}
     node_ids_by_face::T
 end
 Wedge() = Wedge(nothing)
 
-struct Pyr{T} <: AbstractElemShape{3}
+struct Pyr{T} <: AbstractElementShape{3}
     node_ids_by_face::T
 end
 Pyr() = Pyr(nothing)
 
-export AbstractElemShape
-export AbstractTensorProductElement, AbstractSimplexElement
+# TODO: deprecate AbstractElemShape{NDIMS} - it's just an alias for AbstractElementShape
+const AbstractElemShape{NDIMS} = AbstractElementShape{NDIMS}
+export AbstractElemShape 
+
+export AbstractElementShape, AbstractTensorProductElement, AbstractSimplexElement
 export Line
 export Tri, Quad
 export Hex, Wedge, Pyr, Tet

--- a/src/NodesAndModes.jl
+++ b/src/NodesAndModes.jl
@@ -33,7 +33,7 @@ Pyr() = Pyr(nothing)
 
 # TODO: deprecate AbstractElemShape{NDIMS} - it's just an alias for AbstractElementShape
 const AbstractElemShape{NDIMS} = AbstractElementShape{NDIMS}
-export AbstractElemShape 
+export AbstractElemShape
 
 export AbstractElementShape, AbstractTensorProductElement, AbstractSimplexElement
 export Line

--- a/src/common_functions.jl
+++ b/src/common_functions.jl
@@ -14,7 +14,6 @@ Computes the generalized Vandermonde derivative matrix V of degree N at points (
 grad_vandermonde(elem::AbstractElementShape, N, rst...) = basis(elem, N, rst...)[2:end]
 grad_vandermonde(elem::Line, N, r) = last(basis(elem, N, r)) # specialize for 1D
 
-
 """
     nodes(elem::AbstractElementShape,N)
 
@@ -26,15 +25,12 @@ using a tensor product of lower-dimensional nodes.
 """
 nodes(elem::AbstractElementShape, N) = build_warped_nodes(elem, N, nodes(Line(), N))
 
-
-
 """
     basis(elem::AbstractElementShape, N, rst...)
 
 Computes orthonormal basis of degree N at tuple of coordinate arrays (r,s,t).
 """
 basis(elem::AbstractElementShape, N, rst...)
-
 
 """
     equi_nodes(elem::AbstractElementShape, N)

--- a/src/common_functions.jl
+++ b/src/common_functions.jl
@@ -1,22 +1,22 @@
 """
-    vandermonde(elem::AbstractElemShape, N, rst...)
+    vandermonde(elem::AbstractElementShape, N, rst...)
 
 Computes the generalized Vandermonde matrix V of degree N at points (r,s,t).
 """
-vandermonde(elem::AbstractElemShape, N, rst...) = first(basis(elem,N,rst...))
-vandermonde(elem::Line, N, r) = first(basis(elem,N,r)) # specialize for 1D
+vandermonde(elem::AbstractElementShape, N, rst...) = first(basis(elem, N, rst...))
+vandermonde(elem::Line, N, r) = first(basis(elem, N, r)) # specialize for 1D
 
 """
-    grad_vandermonde(elem::AbstractElemShape, N, rst...)
+    grad_vandermonde(elem::AbstractElementShape, N, rst...)
 
 Computes the generalized Vandermonde derivative matrix V of degree N at points (r,s,t).
 """
-grad_vandermonde(elem::AbstractElemShape, N, rst...) = basis(elem, N, rst...)[2:end]
-grad_vandermonde(elem::Line, N, r) = last(basis(elem,N,r)) # specialize for 1D
+grad_vandermonde(elem::AbstractElementShape, N, rst...) = basis(elem, N, rst...)[2:end]
+grad_vandermonde(elem::Line, N, r) = last(basis(elem, N, r)) # specialize for 1D
 
 
 """
-    nodes(elem::AbstractElemShape,N)
+    nodes(elem::AbstractElementShape,N)
 
 Computes interpolation nodes of degree N. Edge nodes coincide with (N+1)-point Lobatto points.
 Default routine for elem = Tet(), Pyr(), Tri().
@@ -24,37 +24,37 @@ Default routine for elem = Tet(), Pyr(), Tri().
 For Quad(), Hex(), Wedge() elements, nodes(...) returns interpolation points constructed
 using a tensor product of lower-dimensional nodes. 
 """
-nodes(elem::AbstractElemShape,N) = build_warped_nodes(elem, N, nodes(Line(),N))
+nodes(elem::AbstractElementShape, N) = build_warped_nodes(elem, N, nodes(Line(), N))
 
 
 
 """
-    basis(elem::AbstractElemShape, N, rst...)
+    basis(elem::AbstractElementShape, N, rst...)
 
 Computes orthonormal basis of degree N at tuple of coordinate arrays (r,s,t).
 """
-basis(elem::AbstractElemShape,N,rst...)
+basis(elem::AbstractElementShape, N, rst...)
 
 
 """
-    equi_nodes(elem::AbstractElemShape, N)
+    equi_nodes(elem::AbstractElementShape, N)
 
 Compute equispaced nodes of degree N.
 """
-equi_nodes(elem::AbstractElemShape, N)
+equi_nodes(elem::AbstractElementShape, N)
 
 """
-    quad_nodes(elem::AbstractElemShape, N)
+    quad_nodes(elem::AbstractElementShape, N)
 
 Compute quadrature nodes and weights exact for (at least) degree 2N polynomials.
 """
-quad_nodes(elem::AbstractElemShape, N)
+quad_nodes(elem::AbstractElementShape, N)
 
 
 """
-    stroud_quad_nodes(elem::AbstractElemShape,N)
+    stroud_quad_nodes(elem::AbstractElementShape,N)
 
 Returns Stroud-type quadrature nodes and weights constructed from the tensor product
 of (N+1)-point Gauss-Jacobi rules. Exact for degree 2N polynomials
 """
-stroud_quad_nodes(elem::AbstractElemShape, N)
+stroud_quad_nodes(elem::AbstractElementShape, N)

--- a/src/warpblend_interp_nodes.jl
+++ b/src/warpblend_interp_nodes.jl
@@ -10,18 +10,23 @@ Returns list of edges for a specific element (elem = Tri(), Pyr(), Hex(), or Tet
 """
 get_edge_list(elem::AbstractElementShape)
 
-get_edge_list(elem::Union{Tri,Quad}) =
+function get_edge_list(elem::Union{Tri, Quad})
     SVector{2}.(find_face_nodes(elem, equi_nodes(elem, 1)...))
-get_edge_list(::Tet) =
-    SVector(1, 4), SVector(4, 3), SVector(3, 1), SVector(1, 2), SVector(3, 2), SVector(4, 2)
-get_edge_list(::Pyr) = SVector(1, 2),
-SVector(2, 4),
-SVector(3, 4),
-SVector(3, 1),
-SVector(1, 5),
-SVector(2, 5),
-SVector(3, 5),
-SVector(4, 5)
+end
+function get_edge_list(::Tet)
+    SVector(1, 4), SVector(4, 3), SVector(3, 1), SVector(1, 2), SVector(3, 2), SVector(4,
+                                                                                       2)
+end
+function get_edge_list(::Pyr)
+    SVector(1, 2),
+    SVector(2, 4),
+    SVector(3, 4),
+    SVector(3, 1),
+    SVector(1, 5),
+    SVector(2, 5),
+    SVector(3, 5),
+    SVector(4, 5)
+end
 
 # edges = recursive ±xyz ordering on each face
 # 
@@ -32,22 +37,23 @@ SVector(4, 5)
 # |/     |/ 
 # 1 ---- 3      
 
-get_edge_list(::Hex) = SVector(1, 5),
-SVector(3, 7),
-SVector(2, 6),
-SVector(4, 8),
-SVector(1, 3),
-SVector(2, 4),
-SVector(1, 2),
-SVector(3, 4),
-SVector(5, 7),
-SVector(6, 8),
-SVector(5, 6),
-SVector(7, 8)
-
+function get_edge_list(::Hex)
+    SVector(1, 5),
+    SVector(3, 7),
+    SVector(2, 6),
+    SVector(4, 8),
+    SVector(1, 3),
+    SVector(2, 4),
+    SVector(1, 2),
+    SVector(3, 4),
+    SVector(5, 7),
+    SVector(6, 8),
+    SVector(5, 6),
+    SVector(7, 8)
+end
 
 get_vertices(elem::AbstractElementShape) = equi_nodes(elem, 1)
-get_vertex_fxns(elem::AbstractElementShape) =
+function get_vertex_fxns(elem::AbstractElementShape)
     (rst...) -> vandermonde(elem, 1, rst...) / vandermonde(elem, 1, equi_nodes(elem, 1)...)
 end
 
@@ -85,14 +91,12 @@ function edge_basis(elem::AbstractElementShape, N, rst...)
     vertices = get_vertices(elem)
     edges = get_edge_list(elem)
     vertex_functions = get_vertex_fxns(elem)
-    return edge_basis(
-        N,
-        vertices,
-        edges,
-        (N, r) -> basis(Line(), N, r),
-        vertex_functions,
-        rst...,
-    )
+    return edge_basis(N,
+                      vertices,
+                      edges,
+                      (N, r) -> basis(Line(), N, r),
+                      vertex_functions,
+                      rst...)
 end
 
 """

--- a/src/warpblend_interp_nodes.jl
+++ b/src/warpblend_interp_nodes.jl
@@ -4,15 +4,24 @@
 #####
 
 """
-    get_edge_list(elem::AbstractElemShape)
+    get_edge_list(elem::AbstractElementShape)
 
 Returns list of edges for a specific element (elem = Tri(), Pyr(), Hex(), or Tet()).
 """
-get_edge_list(elem::AbstractElemShape)
+get_edge_list(elem::AbstractElementShape)
 
-get_edge_list(elem::Union{Tri, Quad}) = SVector{2}.(find_face_nodes(elem, equi_nodes(elem, 1)...))
-get_edge_list(::Tet)  = SVector(1, 4), SVector(4, 3), SVector(3, 1), SVector(1, 2), SVector(3, 2), SVector(4, 2)
-get_edge_list(::Pyr)  = SVector(1, 2), SVector(2, 4), SVector(3, 4), SVector(3, 1), SVector(1, 5), SVector(2, 5), SVector(3, 5), SVector(4, 5)
+get_edge_list(elem::Union{Tri,Quad}) =
+    SVector{2}.(find_face_nodes(elem, equi_nodes(elem, 1)...))
+get_edge_list(::Tet) =
+    SVector(1, 4), SVector(4, 3), SVector(3, 1), SVector(1, 2), SVector(3, 2), SVector(4, 2)
+get_edge_list(::Pyr) = SVector(1, 2),
+SVector(2, 4),
+SVector(3, 4),
+SVector(3, 1),
+SVector(1, 5),
+SVector(2, 5),
+SVector(3, 5),
+SVector(4, 5)
 
 # edges = recursive ±xyz ordering on each face
 # 
@@ -22,28 +31,37 @@ get_edge_list(::Pyr)  = SVector(1, 2), SVector(2, 4), SVector(3, 4), SVector(3, 
 # | 2 ___| 4
 # |/     |/ 
 # 1 ---- 3      
- 
-get_edge_list(::Hex) = SVector(1, 5), SVector(3, 7), SVector(2, 6), SVector(4, 8), 
-                       SVector(1, 3), SVector(2, 4), SVector(1, 2), SVector(3, 4), 
-                       SVector(5, 7), SVector(6, 8), SVector(5, 6), SVector(7, 8)
+
+get_edge_list(::Hex) = SVector(1, 5),
+SVector(3, 7),
+SVector(2, 6),
+SVector(4, 8),
+SVector(1, 3),
+SVector(2, 4),
+SVector(1, 2),
+SVector(3, 4),
+SVector(5, 7),
+SVector(6, 8),
+SVector(5, 6),
+SVector(7, 8)
 
 
-get_vertices(elem::AbstractElemShape) = equi_nodes(elem, 1)
-get_vertex_fxns(elem::AbstractElemShape) =
+get_vertices(elem::AbstractElementShape) = equi_nodes(elem, 1)
+get_vertex_fxns(elem::AbstractElementShape) =
     (rst...) -> vandermonde(elem, 1, rst...) / vandermonde(elem, 1, equi_nodes(elem, 1)...)
 
 # assumes r1D in [-1,1], v1, v2 are vertices
 function interp_1D_to_line(r1D, v1, v2)
     runit = @. (1 + r1D) / 2
-    return map((a,b) -> (b-a) * runit .+ a, v1, v2)
+    return map((a, b) -> (b - a) * runit .+ a, v1, v2)
 end
 
 """
-    interp_1D_to_edges(elem::AbstractElemShape, r1D)
+    interp_1D_to_edges(elem::AbstractElementShape, r1D)
 
 Interpolates points r1D to the edges of an element (elem = :Tri, :Pyr, or :Tet)
 """
-function interp_1D_to_edges(elem::AbstractElemShape, r1D)
+function interp_1D_to_edges(elem::AbstractElementShape, r1D)
     v = get_vertices(elem)
     edges = get_edge_list(elem)
     edge_pts = ntuple(x -> zeros(length(r1D), length(edges)), length(v))
@@ -55,18 +73,25 @@ function interp_1D_to_edges(elem::AbstractElemShape, r1D)
 end
 
 """
-    edge_basis(elem::AbstractElemShape, N, rst...)
+    edge_basis(elem::AbstractElementShape, N, rst...)
 
 Returns the generalized Vandermonde matrix evaluated using an edge basis (e.g.,
 degree `N` polynomials over an edge, but linearly blended into the interior). The 
 dimension of the resulting space is simply the number of total nodes on edges of 
 a degree `N` element. 
 """
-function edge_basis(elem::AbstractElemShape, N, rst...)
+function edge_basis(elem::AbstractElementShape, N, rst...)
     vertices = get_vertices(elem)
     edges = get_edge_list(elem)
     vertex_functions = get_vertex_fxns(elem)
-    return edge_basis(N, vertices, edges, (N, r)->basis(Line(), N, r), vertex_functions, rst...)
+    return edge_basis(
+        N,
+        vertices,
+        edges,
+        (N, r) -> basis(Line(), N, r),
+        vertex_functions,
+        rst...,
+    )
 end
 
 """
@@ -226,20 +251,20 @@ function face_basis(elem, N, r, s, t)
 end
 
 """
-    build_warped_nodes(elem::AbstractElemShape, N, r1D)
+    build_warped_nodes(elem::AbstractElementShape, N, r1D)
 
 Computes degree N warp-and-blend interpolation nodes for elem = Tri(), Pyr(), or
 Tet() based on the 1D node set "r1D". Returns a tuple "rst" containing arrays of
 interpolation points.
 """
-function build_warped_nodes(elem::AbstractElemShape, N, r1D)
+function build_warped_nodes(elem::AbstractElementShape, N, r1D)
     r1D_equi = equi_nodes(Line(), N)
     rst_edge_equi = interp_1D_to_edges(elem, r1D_equi)
     V_edge = edge_basis(elem, N, rst_edge_equi...)
-    rst_edge = interp_1D_to_edges(elem,r1D)
+    rst_edge = interp_1D_to_edges(elem, r1D)
 
-    c = (x->V_edge \ x).(rst_edge) # should be lsq solve
+    c = (x -> V_edge \ x).(rst_edge) # should be lsq solve
 
     rst_equi = equi_nodes(elem, N)
-    return (x->edge_basis(elem, N, rst_equi...) * x).(c)
+    return (x -> edge_basis(elem, N, rst_equi...) * x).(c)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,37 +2,55 @@ using NodesAndModes
 using Test
 using LinearAlgebra
 
+@testset "Types" begin
+    for elem in (Line(), Quad(), Hex())
+        @test elem isa AbstractElementShape
+        @test elem isa AbstractTensorProductElement
+        @test !(elem isa AbstractSimplexElement)
+    end
+    for elem in (Tri(), Tet())
+        @test elem isa AbstractElementShape
+        @test elem isa AbstractSimplexElement
+        @test !(elem isa AbstractTensorProductElement)
+    end
+    for elem in (Wedge(), Pyr())
+        @test elem isa AbstractElementShape
+        @test !(elem isa AbstractSimplexElement)
+        @test !(elem isa AbstractTensorProductElement)
+    end
+end
+
 @testset "1D tests" begin
-    tol = 1e2*eps()
+    tol = 1e2 * eps()
 
     N = 0
-    r,w = gauss_lobatto_quad(0,0,N)
+    r, w = gauss_lobatto_quad(0, 0, N)
     @test sum(w) ≈ 2
 
     for N = 1:2
-        r,w = gauss_quad(0,0,N)
+        r, w = gauss_quad(0, 0, N)
         @test sum(w) ≈ 2
-        @test abs(sum(w.*r)) < tol
+        @test abs(sum(w .* r)) < tol
 
-        V = vandermonde(Line(),N,r)
-        @test V'*diagm(w)*V ≈ I
+        V = vandermonde(Line(), N, r)
+        @test V' * diagm(w) * V ≈ I
 
-        Vr = grad_vandermonde(Line(),N,r)
-        Dr = Vr/V
-        @test norm(sum(Dr,dims=2)) < tol
-        @test Dr*r ≈ ones(N+1)
+        Vr = grad_vandermonde(Line(), N, r)
+        Dr = Vr / V
+        @test norm(sum(Dr, dims = 2)) < tol
+        @test Dr * r ≈ ones(N + 1)
 
-        r,w = gauss_lobatto_quad(0,0,N)
+        r, w = gauss_lobatto_quad(0, 0, N)
         @test sum(w) ≈ 2
-        @test abs(sum(w.*r)) < tol
+        @test abs(sum(w .* r)) < tol
 
         # check if Lobatto is exact for 2N-2 polynoms
-        V = vandermonde(Line(),N-1,r)
-        @test V'*diagm(w)*V ≈ I
+        V = vandermonde(Line(), N - 1, r)
+        @test V' * diagm(w) * V ≈ I
 
-        Dr = grad_vandermonde(Line(),N,r)/vandermonde(Line(),N,r)
-        @test norm(sum(Dr,dims=2)) < tol
-        @test Dr*r ≈ ones(N+1)
+        Dr = grad_vandermonde(Line(), N, r) / vandermonde(Line(), N, r)
+        @test norm(sum(Dr, dims = 2)) < tol
+        @test Dr * r ≈ ones(N + 1)
     end
 
     @test NodesAndModes.face_vertices(Line()) == (1, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ end
     r, w = gauss_lobatto_quad(0, 0, N)
     @test sum(w) ≈ 2
 
-    for N = 1:2
+    for N in 1:2
         r, w = gauss_quad(0, 0, N)
         @test sum(w) ≈ 2
         @test abs(sum(w .* r)) < tol


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily refactors the element-type hierarchy and method signatures; runtime behavior should be unchanged, with the main risk being downstream dispatch/typing assumptions despite the `AbstractElemShape` alias.
> 
> **Overview**
> Introduces a new element type hierarchy by renaming `AbstractElemShape` to `AbstractElementShape` and adding `AbstractTensorProductElement` (Line/Quad/Hex) and `AbstractSimplexElement` (Tri/Tet) supertypes for clearer dispatch.
> 
> Updates core APIs (`vandermonde`, `grad_vandermonde`, `nodes`, `basis`, and warp/blend helpers) to dispatch on `AbstractElementShape`, keeps backward compatibility via `const AbstractElemShape = AbstractElementShape`, and adds tests validating the new type relationships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c98f1cb82b051af9bda2e7e19593e84394f69f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->